### PR TITLE
add missing alias

### DIFF
--- a/app/Http/Controllers/Api/SensorController.php
+++ b/app/Http/Controllers/Api/SensorController.php
@@ -7,6 +7,7 @@ use App\User;
 use App\Sensor;
 use App\Setting;
 use App\Category;
+use App\Measurement;
 // use App\Transformer\SensorTransformer;
 use Validator;
 use InfluxDB;


### PR DESCRIPTION
Creating a new sensor gave the error `Class 'App\\Http\\Controllers\\Api\\Measurement' not found at /opt/beep/BEEP/app/Http/Controllers/Api/SensorController.php:29)`.
Adding the missing alias to the file fixed this error.