### PR TITLE
Add docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM composer:latest
+RUN apk upgrade --update && apk add \
+        freetype-dev \
+        libjpeg-turbo-dev \
+        libpng-dev \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j$(nproc) gd
+WORKDIR /beep
+COPY . /beep
+RUN ls -l && composer install && mv storage storage.bak && chmod -R 777 bootstrap/cache
+
+
+
+FROM php:7.4-apache
+WORKDIR /var/www/html/
+COPY --from=0 /beep/ .
+COPY apache/docker.conf /etc/apache2/sites-enabled/
+RUN apt-get update && apt-get install -y \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libpng-dev \
+        netcat \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j$(nproc) gd && docker-php-ext-install pdo pdo_mysql \
+    && a2enmod rewrite \
+    && sed -i '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' \
+    /etc/apache2/apache2.conf
+
+
+ENTRYPOINT [ "./docker-run.sh" ]

--- a/apache/beep-public.conf
+++ b/apache/beep-public.conf
@@ -17,5 +17,25 @@
             Require not ip 182.254.193.87
         </RequireAll>
     </IfVersion>
+    # ------------------------------------------------------------------------------
+    # | FORCE HTTPS                                                                |
+    # ------------------------------------------------------------------------------
+    <IfModule mod_rewrite.c>
+    
+        # Basic settings
+        <IfModule mod_negotiation.c>
+            Options +FollowSymLinks
+        </IfModule>
+        
+        RewriteEngine On
 
+        RewriteBase /
+
+        # rewrite to https, unless on development or address is /api/unsecure_sensors
+        RewriteCond %{SERVER_PORT} !^443
+        RewriteCond %{THE_REQUEST} !^(POST).*(api/unsecure_sensors)
+        # RewriteCond %{THE_REQUEST} !^(GET).*(info)
+        RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+
+    </IfModule>
 </Directory>

--- a/apache/docker.conf
+++ b/apache/docker.conf
@@ -1,0 +1,25 @@
+<VirtualHost *:80>
+    ServerName localhost
+    DocumentRoot "/var/www/html/public/"
+    <Directory "/var/www/html/public/">
+
+        Options +FollowSymlinks -Indexes -MultiViews
+
+        # Enable .htaccess files to override directives by AllowOverride All
+        AllowOverride All
+
+        <IfVersion < 2.3 >
+            Order allow,deny
+            Allow from all
+        </IfVersion>
+
+        <IfVersion >= 2.3>
+            <RequireAll>
+                Require all granted
+                # blacklist ip address
+                Require not ip 182.254.193.87
+            </RequireAll>
+        </IfVersion>
+
+    </Directory>
+</VirtualHost>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,108 @@
+version: '3.3'
+
+services:
+  mysql:
+    image: mysql:5.7
+    volumes:
+       - mysql_data:/var/lib/mysql
+    restart: always
+    environment:
+       MYSQL_ROOT_PASSWORD: kuchen42
+       MYSQL_DATABASE: bee_data
+       MYSQL_USER: user
+       MYSQL_PASSWORD: pass
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
+  influxdb:
+    image: influxdb:1.5.4-alpine
+    volumes: 
+      - influx_data:/var/lib/influxdb
+    healthcheck:
+      test: "ln -sf /bin/busybox /bin/wget && /bin/wget -q -Y off http://localhost:8086/metrics -O /dev/null > /dev/null 2>&1"
+      interval: 25s
+      timeout: 3s
+    restart: always
+    environment: 
+      INFLUXDB_DB: bee_data
+      INFLUXDB_USER: user_influx
+      INFLUXDB_USER_PASSWORD: pass_influx
+  beep:
+    image: beep:dev
+    restart: always
+    stdin_open: true
+    tty: true
+    ports:
+      - "8000:80"
+    volumes: 
+      - storage_data:/var/www/html/storage
+    depends_on:
+      - mysql
+      - influxdb
+    environment:
+      APP_ENV: local
+      APP_KEY: ohb0jaFa8joceeDaiW3Ohcho0oMaikae # Random key with 32 characters
+      APP_DEBUG: "true"
+      APP_URL: http://localhost:8000/
+      APP_NAME: BEEP 
+      API_URL: http://localhost:8000/api/
+
+      LOG_CHANNEL: stack
+
+      DB_CONNECTION: mysql
+      DB_HOST: mysql
+      DB_PORT: 3306
+      DB_DATABASE: bee_data
+      DB_USERNAME: user
+      DB_PASSWORD: pass
+
+      DB_DATABASE_BACKUP: bee_backup
+      DB_USERNAME_BACKUP: user
+      DB_PASSWORD_BACKUP: pass
+
+      LARAVEL_INFLUX_PROVIDER_PROTOCOL: http
+      LARAVEL_INFLUX_PROVIDER_USER: user_influx
+      LARAVEL_INFLUX_PROVIDER_PASSWORD: pass_influx
+      LARAVEL_INFLUX_PROVIDER_HOST: influxdb
+      LARAVEL_INFLUX_PROVIDER_PORT: 8086
+      LARAVEL_INFLUX_PROVIDER_DATABASE: bee_data
+
+      BROADCAST_DRIVER: log
+      CACHE_DRIVER: array
+      QUEUE_CONNECTION: sync
+      SESSION_DRIVER: file
+      SESSION_LIFETIME: 120
+
+      REDIS_HOST: 127.0.0.1
+      REDIS_PASSWORD: null
+      REDIS_PORT: 6379
+
+      MAIL_DRIVER: smtp
+      MAIL_HOST: 
+      MAIL_PORT: 
+      MAIL_USERNAME: 
+      MAIL_PASSWORD: 
+      MAIL_ENCRYPTION: ssl
+      MAIL_FROM_ADDRESS: 
+      MAIL_FROM_NAME:
+
+      PUSHER_APP_ID: 
+      PUSHER_KEY: 
+      PUSHER_SECRET: 
+      PUSHER_APP_CLUSTER: mt1
+
+      MIX_PUSHER_APP_KEY: "${PUSHER_APP_KEY}"
+      MIX_PUSHER_APP_CLUSTER: "${PUSHER_APP_CLUSTER}"
+
+      DEBUGBAR_ENABLED: "false"
+
+      WEBAPP_URL: "http://localhost:8000/webapp#!/"
+      WEBAPP_EMAIL_VERIFY_URL: login
+      WEBAPP_PASSWORD_RESET_URL: "login/reset/"
+
+      GOOGLE_MAPS_KEY: 
+volumes:
+    mysql_data: {}
+    influx_data: {}
+    storage_data: {}

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -x
+set -e
+
+pwd
+
+# Setup Storage Directory structure
+mkdir -p storage/app/public
+mkdir -p storage/framework/cache/data
+mkdir -p storage/framework/sessions
+mkdir -p storage/framework/views
+mkdir -p storage/logs
+cp storage.bak/app/new_taxonomy_tables.sql storage/app
+chmod 777 -R storage
+
+
+# Migrate DB
+php artisan migrate
+
+# Link storage
+php artisan storage:link
+
+# Set API_URL
+sed -i '/^var API_URL/d' public/app/js/constants.js
+echo "" >> public/app/js/constants.js
+echo "var API_URL = '${API_URL}';" >> public/app/js/constants.js
+
+cat public/app/js/constants.js
+
+# Start Service
+apache2-foreground

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,25 +1,5 @@
 
-# ------------------------------------------------------------------------------
-# | FORCE HTTPS                                                                |
-# ------------------------------------------------------------------------------
-<IfModule mod_rewrite.c>
-   
-    # Basic settings
-    <IfModule mod_negotiation.c>
-        Options +FollowSymLinks
-    </IfModule>
-    
-    RewriteEngine On
 
-    RewriteBase /
-
-    # rewrite to https, unless on development or address is /api/unsecure_sensors
-    RewriteCond %{SERVER_PORT} !^443
-    RewriteCond %{THE_REQUEST} !^(POST).*(api/unsecure_sensors)
-    # RewriteCond %{THE_REQUEST} !^(GET).*(info)
-    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
-
-</IfModule>
 
 # ------------------------------------------------------------------------------
 # | LARAVEL                                                                    |

--- a/readme.md
+++ b/readme.md
@@ -153,6 +153,22 @@ e. You should see the back-end dashboard, looking like this:
 ## Management interface
 ![BEEP Management interface](https://github.com/beepnl/BEEP/blob/bob-additions/BEEP-management-interface.png)
 
+# Installation using docker compose
+
+A simple setup for small installations can be achived with [docker-compose](https://docs.docker.com/compose/). The tool will spinn up a mysqldb, influd, a webserver and initialize the beep database.
+
+1. [Install docker-compose](https://docs.docker.com/compose/install/)
+2. Checkout BEEP and switch into the code repository
+3. Adjust `docker-compose.yaml`(set suitable environment variables).
+4. Run `docker-compose up`. During the first start, you might see some database connectivity issues. Docker compose will restart the BEEP Server component untill a database connection is available. So don't worry.
+5. Register as a new user: [http://localhost:8000/webapp](http://localhost:8000/webapp).
+6. Grant user administrator rights: `docker-compose exec  mysql mysql -h localhost -P 3306 -ppass -u user -D bee_data -Bse "INSERT INTO role_user (user_id,role_id) VALUES(1,1);"`
+7. Login to mamagement interface: [http://localhost:8000/admin](http://localhost:8000/admin)
+
+To upgrade beep to the latest version, simply stop and start docker-compose.
+
+As the setup is based on docker containers, code changes inside the repository will not have an effeact till the underlying docker image is updated. 
+
 
 # Contributing
 


### PR DESCRIPTION
A manual deployment on a virtual machine is pretty time consuming. Docker compose is taking care of setting up the infrastructure and running beep. 

The change proposed is not doing any changes to the existing code except of some minor apache / htaccess changes. 