### PR TITLE
Flashlog import improvement

### DIFF
--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -239,15 +239,17 @@ class FlashLogController extends Controller
         return $data_array;
     }
 
-    private function diff_percentage($val1, $val2)
+    private function diff_percentage($val1, $val2, $round_decimals=1)
     {
-        $diff = abs($val1 - $val2);
-        $ave  = ($val1 + $val2) / 2;
+        $rval1= round($val1,$round_decimals);
+        $rval2= round($val2,$round_decimals);
+        $diff = abs($rval1 - $rval2);
+        $ave  = ($rval1 + $rval2) / 2;
         return $ave != 0 ? 100 * $diff / $ave : 0;
     }
 
 
-    private function matchPercentage($array1, $array2, $match_props=9, $max_diff_percentage=1) // flashlog_array, database_array
+    private function matchPercentage($array1, $array2, $match_props=9, $max_diff_percentage=0) // flashlog_array, database_array
     {
         //$matches       = [];
         $secDiff       = [];
@@ -277,7 +279,7 @@ class FlashLogController extends Controller
                         continue;
                     }
 
-                    if (isset($f['bv']) && isset($d['bv']) && $this->diff_percentage($f['bv'], $d['bv']) < $max_diff_percentage) // first fast check
+                    if (isset($f['bv']) && isset($d['bv']) && $this->diff_percentage($f['bv'], $d['bv'], 3) <= $max_diff_percentage) // first fast check
                     {
                         $match = array_intersect_assoc($d, $f);
 
@@ -677,6 +679,7 @@ class FlashLogController extends Controller
                                 
                                 $interval_min  = $interval_min * $interval_multi;
                                 $fl_i_modulo   = $interval_multi;
+                                $max_diff_perc = $interval_multi - 1; // 0-11% diff
 
                                 $match_index   = $block['fl_i'];
                                 $index_amount  = round($data_minutes / $interval_min);
@@ -694,7 +697,7 @@ class FlashLogController extends Controller
                                 $start_index = $block_start_i + ($index_amount * $block_data_i);
                                 $end_index   = min($block_end_i, $block_start_i + ($index_amount * ($block_data_i+1)));
 
-                                $out = ['interval_min'=>$interval_min, 'data_point_modulo'=>$fl_i_modulo, 'block_start_i'=>$block_start_i, 'block_end_i'=>$block_end_i, 'match_index'=>$match_index, 'block_data_index'=>$block_data_i, 'block_data_index_max'=>$data_i_max, 'block_data_index_amount'=>$index_amount, 'block_data_start'=>$start_index, 'block_data_end'=>$end_index, 'flashlog'=>[], 'database'=>[]];
+                                $out = ['interval_min'=>$interval_min, 'data_point_modulo'=>$fl_i_modulo, 'max_diff_perc'=>$max_diff_perc, 'block_start_i'=>$block_start_i, 'block_end_i'=>$block_end_i, 'match_index'=>$match_index, 'block_data_index'=>$block_data_i, 'block_data_index_max'=>$data_i_max, 'block_data_index_amount'=>$index_amount, 'block_data_start'=>$start_index, 'block_data_end'=>$end_index, 'flashlog'=>[], 'database'=>[]];
 
                                 // Add flashlog measurement data
                                 $modulo_counter = 0; // counter that starts at 0 (like DB $i)

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -307,7 +307,7 @@ class FlashLogController extends Controller
                                         if (in_array($m_key.'_different', $errors) == false)
                                             $errors[] = $m_key.'_different';
 
-                                        Log::error("match fl_arr[$i] to db_arr[$j] $m_key diff_perc=$diff_perc: fl=$f[$m_key] db=$d[$m_key]");
+                                        Log::error("match fl_arr[$i] to db_arr[$j] $m_key diff_perc=$diff_perc: fl=$f[$m_key] db=$d[$m_key] @ $d_time");
                                     }
                                 }
                             }

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -320,6 +320,7 @@ class FlashLogController extends Controller
                             
                         }
                     }
+                    Log::debug("match ($match_ok) fl_arr[$i]: ".json_encode($f)." with db_arr[$j]: ".json_encode($d));
                 }
             }
         }

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -292,26 +292,27 @@ class FlashLogController extends Controller
                                 $diff_perc = $this->diff_percentage($d[$m_key], $f[$m_key]);
                                 $percDiff[]= $diff_perc;
 
-                                if ($diff_perc <= $max_diff_percentage)
+                                if ($diff_perc <= $max_diff_percentage) // m_key matches
                                 {
-                                    $matches++;
-                                }
-                                else if (in_array($m_key, $should_match))
-                                {
-                                    if ($m_key == 'weight_kg' && abs($d[$m_key]) > 200 && abs($f[$m_key]) > 200) // can still be ok, because uncalibrated db values can be replaced
+                                    $match_ok = true;
+                                    if (in_array($m_key, $should_match))
                                     {
+                                        if ($m_key == 'weight_kg' && abs($d[$m_key]) > 200 && abs($f[$m_key]) > 200) // can still be ok, because uncalibrated db values can be replaced
+                                        {
+                                            if (in_array($m_key.'_uncalibrated', $errors) == false)
+                                                $errors[] = $m_key.'_uncalibrated';
+                                        }
+                                        else
+                                        {
+                                            // reject match, because weight_kg, t_i, t_0, or t_1 does not match
+                                            $match_ok = false;
+
+                                            if (in_array($m_key.'_different', $errors) == false)
+                                                $errors[] = $m_key.'_different';
+                                        }
+                                    }
+                                    if ($match_ok) // count this measurement as a match
                                         $matches++;
-
-                                        if (in_array($m_key.'_uncalibrated', $errors) == false)
-                                            $errors[] = $m_key.'_uncalibrated';
-                                    }
-                                    else
-                                    {
-                                        if (in_array($m_key.'_different', $errors) == false)
-                                            $errors[] = $m_key.'_different';
-
-                                        Log::error("match fl_arr[$i] to db_arr[$j] $m_key diff_perc=$diff_perc: fl=$f[$m_key] db=$d[$m_key] @ $d_time");
-                                    }
                                 }
                             }
                         }

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -284,7 +284,7 @@ class FlashLogController extends Controller
                         // loop through both array measurements values
                         $matches      = 0; 
                         $should_match = ['weight_kg','t_i','t_0','t_1'];
-                        foreach ($array_keys($d) as $m_key)
+                        foreach (array_keys($d) as $m_key)
                         {
                             if (isset($d[$m_key]) && isset($f[$m_key]))
                             {

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -491,7 +491,7 @@ class FlashLogController extends Controller
                             {
                                 $persist_count= 0;
                                 $db_insert_rec= 4999; // chuck size of records to insert at one POST request
-                                $req_points_db= $block_length / $fl_per_db_int 
+                                $req_points_db= $block_length / $fl_per_db_int;
                                 $req_cnt_db   = ceil($req_points_db / $this->maxDataPoints);
                                 $points_p_req = round($req_points_db / $req_cnt_db);
                                 $secs_per_req = $points_p_req * $interval_db * 60;
@@ -569,7 +569,7 @@ class FlashLogController extends Controller
                                             //print_r(['db_count'=>$db_count, 'm'=>$count_measurements]);
 
                                             $db_count      = array_intersect_key($db_count, $count_measurements); // only keep the key counts from valid matching measurements
-                                            $count_sum     = array_sum($db_count) / $fl_per_db_int                                            
+                                            $count_sum     = array_sum($db_count) / $fl_per_db_int;                                        
                                             $data_per_int_d[$time_start] = $count_sum;
                                             
 
@@ -580,7 +580,7 @@ class FlashLogController extends Controller
                                                 $secOfCountEnd   = strtotime($time_end);
                                                 $minDifWithStart = round(($secOfCountStart - $block_start_u) / 60);
                                                 $indexFlogStart  = $block_start_i + ceil($minDifWithStart / $interval_min);
-                                                $indexFlogEnd    = min($block_end_i, $indexFlogStart + $fl_per_db_int
+                                                $indexFlogEnd    = min($block_end_i, $indexFlogStart + $fl_per_db_int;
                                                 $indexFlogStart  = max(0, $indexFlogStart);
                                                 
                                                 for ($i=$indexFlogStart; $i < $indexFlogEnd; $i++)

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -308,7 +308,7 @@ class FlashLogController extends Controller
                             foreach ($should_match_diff as $m_key => $diff)
                             {
                                 $should_match[$m_key] = $should_match[$m_key] + 1;
-                                if ($m_key == 'weight_kg' && abs($d[$m_key]) > 200 && abs($f[$m_key]) > 200) // can still be ok, because uncalibrated db values can be replaced
+                                if ($m_key == 'weight_kg' && abs($d[$m_key]) < 200 && abs($f[$m_key]) > 200) // can still be ok, because uncalibrated db values can be replaced
                                 {
                                     $errors[$m_key] = "$should_match[$m_key] $m_key values uncalibrated";
                                 }
@@ -316,7 +316,7 @@ class FlashLogController extends Controller
                                 {
                                     // reject match, because weight_kg, t_i, t_0, or t_1 does not match
                                     $match_ok = false;
-                                    $errors[$m_key] = "$should_match[$m_key] $m_key values different";
+                                    $errors[$m_key] = "$should_match[$m_key] $m_key values differ";
                                 }
                             }
                             if ($match_ok) // count this measurement as a match

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -277,7 +277,7 @@ class FlashLogController extends Controller
                         continue;
                     }
 
-                    if (isset($f['bv']) && isset($d['bv']) && diff_percentage($f['bv'], $d['bv']) < $max_diff_percentage) // first fast check
+                    if (isset($f['bv']) && isset($d['bv']) && $this->diff_percentage($f['bv'], $d['bv']) < $max_diff_percentage) // first fast check
                     {
                         $match = array_intersect_assoc($d, $f);
 
@@ -288,7 +288,7 @@ class FlashLogController extends Controller
                             foreach ($should_match as $m_key)
                             {
                                 // reject match, because weight_kg, t_i, t_0, or t_1 does not match
-                                if (isset($d[$m_key]) && isset($f[$m_key]) && diff_percentage($d[$m_key], $f[$m_key]) > $max_diff_percentage)
+                                if (isset($d[$m_key]) && isset($f[$m_key]) && $this->diff_percentage($d[$m_key], $f[$m_key]) > $max_diff_percentage)
                                 {
                                     if ($m_key == 'weight_kg' && $d[$m_key] > 200 && $f[$m_key] < 200) // can still be ok, because uncalibrated db values can be replaced
                                     {

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -329,7 +329,7 @@ class FlashLogController extends Controller
             }
         }
         $secDiffAvg   = count($secDiff) > 0 ? round(array_sum($secDiff)/count($secDiff)) : null;
-        $matchDiffAvg = count($percDiff) > 0 ? round(array_sum($percDiff)/count($percDiff)) : null;
+        $matchDiffAvg = count($percDiff) > 0 ? round(array_sum($percDiff)/count($percDiff), 1) : null;
         $percMatch    = $array_min_len > 0 ? round(100 * ($match_count / $array_min_len), 1): 0;
         //die(print_r([$percMatch, $secDiffAvg, $matches]));
         return ['sec_diff'=>$secDiffAvg, 'perc_match'=>$percMatch, 'avg_diff'=>$matchDiffAvg, 'errors'=>implode(', ', $errors)];

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -288,7 +288,8 @@ class FlashLogController extends Controller
                         {
                             if (isset($d[$m_key]) && isset($f[$m_key]))
                             {
-                                if ($this->diff_percentage($d[$m_key], $f[$m_key]) <= $max_diff_percentage)
+                                $diff_perc = $this->diff_percentage($d[$m_key], $f[$m_key]);
+                                if ($diff_perc <= $max_diff_percentage)
                                 {
                                     $matches++;
                                 }
@@ -305,6 +306,8 @@ class FlashLogController extends Controller
                                     {
                                         if (in_array($m_key.'_different', $errors) == false)
                                             $errors[] = $m_key.'_different';
+
+                                        Log::error("match fl_arr[$i] to db_arr[$j] $m_key diff_perc=$diff_perc: fl=$f[$m_key] db=$d[$m_key]");
                                     }
                                 }
                             }

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -447,10 +447,13 @@ class FlashLogController extends Controller
                             $block_start_u= strtotime($block_start_t);  
                             $block_end_u  = strtotime($block_end_t);  
                             
-                            Log::debug("");
-                            $persist_log = $persist ? '1' : '0';
-                            $delete_log  = $delete ? '1' : '0';
-                            Log::debug("FlashLogController parse device=$device_name, persist=$persist_log, del=$delete_log, fl_id=$flashlog_id, bl_id=$block_id, bl_len=$block_length, bl_st_tm=$block_start_t, bl_st_i=$block_start_i, bl_end_tm=$block_end_t, bl_end_i=$block_end_i, bl_data_i=$block_data_i");
+                            if ($delete || $persist)
+                            {
+                                Log::debug("");
+                                $persist_log = $persist ? '1' : '0';
+                                $delete_log  = $delete ? '1' : '0';
+                                Log::debug("FlashLogController parse device=$device_name, persist=$persist_log, del=$delete_log, fl_id=$flashlog_id, bl_id=$block_id, bl_len=$block_length, bl_st_tm=$block_start_t, bl_st_i=$block_start_i, bl_end_tm=$block_end_t, bl_end_i=$block_end_i, bl_data_i=$block_data_i");
+                            }
 
                             if ($delete)
                             {

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -239,7 +239,7 @@ class FlashLogController extends Controller
         return $data_array;
     }
 
-    private function matchPercentage($array1, $array2, $match_props=9)
+    private function matchPercentage($array1, $array2, $match_props=9) // flashlog_array, database_array
     {
         //$matches       = [];
         $secDiff       = [];
@@ -656,6 +656,23 @@ class FlashLogController extends Controller
                             else // Show data content per $data_minutes
                             {
                                 // select portion of the data
+                                if ($data_minutes > 43200)
+                                {
+                                    $interval_min = 180;
+                                }
+                                else if ($data_minutes > 10080)
+                                {
+                                    $interval_min = 60;
+                                }
+                                else if ($data_minutes > 1440)
+                                {
+                                    $interval_min = 30;
+                                }
+                                else
+                                {
+                                    // leave $interval_min to default (15 min)
+                                }
+
                                 $match_index   = $block['fl_i'];
                                 $index_amount  = round($data_minutes / $interval_min);
                                 $data_i_max    = floor(($block_end_i - $block_start_i) / $index_amount);
@@ -690,7 +707,7 @@ class FlashLogController extends Controller
                                     $last_obj      = $out['flashlog'][$data_values-1];
                                     $start_time    = substr($first_obj['time'], 0, 19); // cut off Z
                                     $end_time      = substr($last_obj['time'], 0, 19); // cut off Z
-                                    $query         = 'SELECT "'.implode('","', $measurements).'" FROM "sensors" WHERE '.$flashlog->device->influxWhereKeys().' AND time >= \''.$start_time.'\' AND time <= \''.$end_time.'\' ORDER BY time ASC LIMIT '.$index_amount;
+                                    $query         = 'SELECT "'.implode('","', $measurements).'" FROM "sensors" WHERE '.$device->influxWhereKeys().' AND time >= \''.$start_time.'\' AND time <= \''.$end_time.'\' ORDER BY time ASC LIMIT '.$index_amount;
                                     $db_data_week  = Device::getInfluxQuery($query, 'flashlog');
                                     $db_data_cln   = [];
                                     foreach ($db_data_week as $db_value)

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -691,7 +691,7 @@ class FlashLogController extends Controller
                                 $start_index = $block_start_i + ($index_amount * $block_data_i);
                                 $end_index   = min($block_end_i, $block_start_i + ($index_amount * ($block_data_i+1)));
 
-                                $out = ['block_start_i'=>$block_start_i, 'block_end_i'=>$block_end_i, 'match_index'=>$match_index, 'block_data_index'=>$block_data_i, 'block_data_index_max'=>$data_i_max, 'block_data_index_amount'=>$index_amount, 'block_data_start'=>$start_index, 'block_data_end'=>$end_index, 'flashlog'=>[], 'database'=>[]];
+                                $out = ['interval_min'=>$interval_min, 'data_point_modulo'=>$fl_i_modulo, 'block_start_i'=>$block_start_i, 'block_end_i'=>$block_end_i, 'match_index'=>$match_index, 'block_data_index'=>$block_data_i, 'block_data_index_max'=>$data_i_max, 'block_data_index_amount'=>$index_amount, 'block_data_start'=>$start_index, 'block_data_end'=>$end_index, 'flashlog'=>[], 'database'=>[]];
 
                                 // Add flashlog measurement data
                                 $modulo_counter = 0; // counter that starts at 0 (like DB $i)

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -442,15 +442,15 @@ class FlashLogController extends Controller
                         // Check if there are matches (NB: Bug: persisted measurements now can only be deleted in a block with matches)
                         if ($has_matches)
                         {
-                            $persist_log = $persist ? '1' : '0';
-                            $delete_log  = $delete ? '1' : '0';
-                            Log::debug("");
-                            Log::debug("FlashLogController parse device=$device_name, persist=$persist_log, delete=$delete_log, flashlog_id=$flashlog_id, block_id=$block_id, block_length=$block_length, block_start_i=$block_start_i, block_end_i=$block_end_i");
-
                             $block_start_t= $block['time_start'];
                             $block_end_t  = $block['time_end'];
                             $block_start_u= strtotime($block_start_t);  
                             $block_end_u  = strtotime($block_end_t);  
+                            
+                            Log::debug("");
+                            $persist_log = $persist ? '1' : '0';
+                            $delete_log  = $delete ? '1' : '0';
+                            Log::debug("FlashLogController parse device=$device_name, persist=$persist_log, del=$delete_log, fl_id=$flashlog_id, bl_id=$block_id, bl_len=$block_length, bl_st_tm=$block_start_t, bl_st_i=$block_start_i, bl_end_tm=$block_end_t, bl_end_i=$block_end_i, bl_data_i=$block_data_i");
 
                             if ($delete)
                             {
@@ -673,7 +673,7 @@ class FlashLogController extends Controller
                                     $interval_multi = 4;
                                 
                                 $interval_min  = $interval_min * $interval_multi;
-                                $fl_i_modulo   = $fl_per_db_int* $interval_multi;
+                                $fl_i_modulo   = $interval_multi;
 
                                 $match_index   = $block['fl_i'];
                                 $index_amount  = round($data_minutes / $interval_min);

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -279,7 +279,7 @@ class FlashLogController extends Controller
                         continue;
                     }
 
-                    if (isset($f['bv']) && isset($d['bv']) && $this->diff_percentage($f['bv'], $d['bv'], 3) <= $max_diff_percentage) // first fast check
+                    if (isset($f['bv']) && isset($d['bv']) && $this->diff_percentage($f['bv'], $d['bv'], 3) <= $max_diff_percentage) // first fast check on similar battery voltages
                     {
                         $match = array_intersect_assoc($d, $f);
 
@@ -734,7 +734,7 @@ class FlashLogController extends Controller
                                     $out['database']   = $db_data_cln;
                                     
                                     // Run through the data to see how many % of the data matches
-                                    $match_percentage = $this->matchPercentage($out['flashlog'], $db_data_cln, $match_props, 10);
+                                    $match_percentage = $this->matchPercentage($out['flashlog'], $db_data_cln, $match_props, $max_diff_perc);
                                     $out['block_data_match_percentage']  = $match_percentage['perc_match'];
                                     $out['block_data_flashlog_sec_diff'] = $match_percentage['sec_diff'];
                                     $out['block_data_match_errors']      = $match_percentage['errors'];

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -239,7 +239,7 @@ class FlashLogController extends Controller
         return $data_array;
     }
 
-    private function matchPercentage($array1, $array2, $match_props=9)
+    private function matchPercentage($array1, $array2, $match_props=9) // flashlog_array, database_array
     {
         //$matches       = [];
         $secDiff       = [];
@@ -690,7 +690,7 @@ class FlashLogController extends Controller
                                     $last_obj      = $out['flashlog'][$data_values-1];
                                     $start_time    = substr($first_obj['time'], 0, 19); // cut off Z
                                     $end_time      = substr($last_obj['time'], 0, 19); // cut off Z
-                                    $query         = 'SELECT "'.implode('","', $measurements).'" FROM "sensors" WHERE '.$flashlog->device->influxWhereKeys().' AND time >= \''.$start_time.'\' AND time <= \''.$end_time.'\' ORDER BY time ASC LIMIT '.$index_amount;
+                                    $query         = 'SELECT "'.implode('","', $measurements).'" FROM "sensors" WHERE '.$device->influxWhereKeys().' AND time >= \''.$start_time.'\' AND time <= \''.$end_time.'\' ORDER BY time ASC LIMIT '.$index_amount;
                                     $db_data_week  = Device::getInfluxQuery($query, 'flashlog');
                                     $db_data_cln   = [];
                                     foreach ($db_data_week as $db_value)
@@ -699,7 +699,7 @@ class FlashLogController extends Controller
                                     $out['database']   = $db_data_cln;
                                     
                                     // Run through the data to see how many % of the data matches
-                                    $match_percentage = $this->matchPercentage($out['flashlog'], $db_data_cln, $match_props);
+                                    $match_percentage = $this->matchPercentage($db_data_cln, $out['flashlog'], $match_props);
                                     $out['block_data_match_percentage']  = $match_percentage['perc_match'];
                                     $out['block_data_flashlog_sec_diff'] = $match_percentage['sec_diff'];
                                     $out['block_data_match_errors']      = $match_percentage['errors'];

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -239,7 +239,7 @@ class FlashLogController extends Controller
         return $data_array;
     }
 
-    private function matchPercentage($array1, $array2, $match_props=9) // flashlog_array, database_array
+    private function matchPercentage($array1, $array2, $match_props=9)
     {
         //$matches       = [];
         $secDiff       = [];
@@ -690,7 +690,7 @@ class FlashLogController extends Controller
                                     $last_obj      = $out['flashlog'][$data_values-1];
                                     $start_time    = substr($first_obj['time'], 0, 19); // cut off Z
                                     $end_time      = substr($last_obj['time'], 0, 19); // cut off Z
-                                    $query         = 'SELECT "'.implode('","', $measurements).'" FROM "sensors" WHERE '.$device->influxWhereKeys().' AND time >= \''.$start_time.'\' AND time <= \''.$end_time.'\' ORDER BY time ASC LIMIT '.$index_amount;
+                                    $query         = 'SELECT "'.implode('","', $measurements).'" FROM "sensors" WHERE '.$flashlog->device->influxWhereKeys().' AND time >= \''.$start_time.'\' AND time <= \''.$end_time.'\' ORDER BY time ASC LIMIT '.$index_amount;
                                     $db_data_week  = Device::getInfluxQuery($query, 'flashlog');
                                     $db_data_cln   = [];
                                     foreach ($db_data_week as $db_value)
@@ -699,7 +699,7 @@ class FlashLogController extends Controller
                                     $out['database']   = $db_data_cln;
                                     
                                     // Run through the data to see how many % of the data matches
-                                    $match_percentage = $this->matchPercentage($db_data_cln, $out['flashlog'], $match_props);
+                                    $match_percentage = $this->matchPercentage($out['flashlog'], $db_data_cln, $match_props);
                                     $out['block_data_match_percentage']  = $match_percentage['perc_match'];
                                     $out['block_data_flashlog_sec_diff'] = $match_percentage['sec_diff'];
                                     $out['block_data_match_errors']      = $match_percentage['errors'];

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -320,7 +320,7 @@ class FlashLogController extends Controller
                             
                         }
                     }
-                    Log::debug("match ($match_ok) fl_arr[$i]: ".json_encode($f)." with db_arr[$j]: ".json_encode($d));
+                    Log::debug("match $match_props props with max $max_diff_percentage%% diff fl_arr[$i]: ".json_encode($f)." with db_arr[$j]: ".json_encode($d));
                 }
             }
         }

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -284,7 +284,8 @@ class FlashLogController extends Controller
                     if (isset($f['bv']) && isset($d['bv']) && $this->diff_percentage($f['bv'], $d['bv'], 3) <= $max_diff_percentage) // first fast check on similar battery voltages
                     {
                         // loop through both array measurements values
-                        $matches      = 0; 
+                        $matches           = 0; 
+                        $should_match_diff = [];
                         foreach (array_keys($d) as $m_key)
                         {
                             if (isset($d[$m_key]) && isset($f[$m_key]))
@@ -294,6 +295,8 @@ class FlashLogController extends Controller
 
                                 if ($diff_perc <= $max_diff_percentage) // m_key matches
                                     $matches++;
+                                else if (in_array($m_key, $should_match))
+                                    $should_match_diff[$m_key] = $diff_perc;
                                 
                             }
                         }
@@ -301,7 +304,7 @@ class FlashLogController extends Controller
                         if ($matches >= $d_val_count-1)
                         {
                             $match_ok = true;
-                            foreach ($should_match as $m_key)
+                            foreach ($should_match_diff as $m_key => $diff)
                             {
                                 if ($m_key == 'weight_kg' && abs($d[$m_key]) > 200 && abs($f[$m_key]) > 200) // can still be ok, because uncalibrated db values can be replaced
                                 {
@@ -316,7 +319,7 @@ class FlashLogController extends Controller
                                     if (in_array($m_key.'_different', $errors) == false)
                                         $errors[] = $m_key.'_different';
 
-                                    Log::error("match fl_arr[$i] to db_arr[$j] $m_key diff_perc=$diff_perc: fl=$f[$m_key] db=$d[$m_key] @ $d_time");
+                                    Log::error("match fl_arr[$i] to db_arr[$j] $m_key diff_perc=$diff: fl=$f[$m_key] db=$d[$m_key] @ $d_time");
                                 }
                             }
                             if ($match_ok) // count this measurement as a match

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -664,7 +664,7 @@ class FlashLogController extends Controller
                                 else if ($data_minutes > 1440)
                                     $interval_multi = 4;
                                 
-                                $interval_min  = $interval_min * $interval_multi
+                                $interval_min  = $interval_min * $interval_multi;
                                 $fl_i_modulo   = $fl_per_db_int* $interval_multi;
 
                                 $match_index   = $block['fl_i'];

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -523,8 +523,8 @@ class FlashLogController extends Controller
                                     // Persist all non-existing Flashlog data to InfluxDB
                                     if ($data_per_int_max_i == -1) // import data where there is NO database data available
                                     {
-                                        $indexFlogStart  = round($block_start_i + ($req_ind * $points_p_req * $fl_per_db_int;
-                                        $indexFlogEnd    = round($block_start_i + (($req_ind+1) * $points_p_req * $fl_per_db_int;
+                                        $indexFlogStart  = round($block_start_i + ($req_ind * $points_p_req * $fl_per_db_int));
+                                        $indexFlogEnd    = round($block_start_i + (($req_ind+1) * $points_p_req * $fl_per_db_int));
                                         
                                         Log::debug("persist_with_no_db_values: indexFlogStart=$indexFlogStart, indexFlogEnd=$indexFlogEnd");
 
@@ -580,7 +580,7 @@ class FlashLogController extends Controller
                                                 $secOfCountEnd   = strtotime($time_end);
                                                 $minDifWithStart = round(($secOfCountStart - $block_start_u) / 60);
                                                 $indexFlogStart  = $block_start_i + ceil($minDifWithStart / $interval_min);
-                                                $indexFlogEnd    = min($block_end_i, $indexFlogStart + $fl_per_db_int;
+                                                $indexFlogEnd    = min($block_end_i, $indexFlogStart + $fl_per_db_int);
                                                 $indexFlogStart  = max(0, $indexFlogStart);
                                                 
                                                 for ($i=$indexFlogStart; $i < $indexFlogEnd; $i++)

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -499,7 +499,7 @@ class FlashLogController extends Controller
                                     if ($data_influx_deleted)
                                     {
                                         $persisted_block_ids_array = $flashlog->persisted_block_ids_array;
-                                        if (count($persisted_block_ids_array) == 0 || (count($persisted_block_ids_array) == 1 && $persisted_block_ids_array[0] == $block_id)))
+                                        if (count($persisted_block_ids_array) == 0 || (count($persisted_block_ids_array) == 1 && $persisted_block_ids_array[0] == $block_id))
                                             $flashlog->persisted_block_ids = null;
                                         else
                                             $flashlog->persisted_block_ids_array = array_diff($flashlog->persisted_block_ids_array, [$block_id]);

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -498,7 +498,12 @@ class FlashLogController extends Controller
                                     
                                     if ($data_influx_deleted)
                                     {
-                                        $flashlog->persisted_block_ids_array = array_diff($flashlog->persisted_block_ids_array, [$block_id]);
+                                        $persisted_block_ids_array = $flashlog->persisted_block_ids_array;
+                                        if (count($persisted_block_ids_array) == 0 || (count($persisted_block_ids_array) == 1 && $persisted_block_ids_array[0] == $block_id)))
+                                            $flashlog->persisted_block_ids = null;
+                                        else
+                                            $flashlog->persisted_block_ids_array = array_diff($flashlog->persisted_block_ids_array, [$block_id]);
+
                                         $flashlog->persisted_measurements = max(0, $flashlog->persisted_measurements - $delete_count_sum);
                                         $flashlog->save();
                                     }

--- a/app/Http/Controllers/Api/FlashLogController.php
+++ b/app/Http/Controllers/Api/FlashLogController.php
@@ -308,7 +308,7 @@ class FlashLogController extends Controller
                             foreach ($should_match_diff as $m_key => $diff)
                             {
                                 $should_match[$m_key] = $should_match[$m_key] + 1;
-                                if ($m_key == 'weight_kg' && abs($d[$m_key]) < 200 && abs($f[$m_key]) > 200) // can still be ok, because uncalibrated db values can be replaced
+                                if ($m_key == 'weight_kg' && abs($d[$m_key]) > 200 && abs($f[$m_key]) < 200) // are still be ok, because uncalibrated db values can be replaced
                                 {
                                     $errors[$m_key] = "$should_match[$m_key] $m_key values uncalibrated";
                                 }


### PR DESCRIPTION
- Add extra error feedback
- Add logging
- Fix import undo empty [0] persisted_block_ids (now becomes NULL again)
- Add possibility to request different amount of `data_minutes` for viewing larger comparison charts with modulo picks in the dataset